### PR TITLE
Make setup process unprivileged and isolated

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Instructions
 ============
 
 1. Run ``bash setup_env.sh``
-2. Run ``source /opt/stack/ansible/hacking/env-setup``
 3. Source your OpenStack cloud environment variables rc file
 3. Run ``cp infra_config.yml.sample infra_config.yml``
 4. Edit infra_config.yml and put your environment values

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+echo $PWD
 ansible-playbook -i hosts provision_infra_servers.yml -e "@infra_config.yml"
-ansible-playbook -i /opt/stack/ansible/contrib/inventory/openstack.py site.yml -e "@infra_config.yml"
+ansible-playbook -i ansible/contrib/inventory/openstack.py site.yml -e "@infra_config.yml"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,53 +1,26 @@
 #!/bin/bash
 set -e
 
-if [ -x '/usr/bin/apt-get' ]; then
-    if ! $(git --version &>/dev/null) ; then
-        sudo -H apt-get -y install git
-    fi
-    if ! $(pip -v &>/dev/null); then
-        sudo -H apt-get -y install python-pip
-    fi
-elif [ -x '/usr/bin/yum' ]; then
-    if ! $(git --version &>/dev/null); then
-        sudo -H yum -y install git
-    fi
-    if ! $(pip -v &>/dev/null); then
-        sudo -H yum -y install python-pip
-    fi
-else
-    echo "ERROR: Supported package manager not found.  Supported: apt,yum"
-fi
+VENV=${INFRA_ANSIBLE_VENV:-"venv"}
 
-sudo -E pip install -r "$(dirname $0)/requirements.txt"
+mkdir -p ${VENV}
+virtualenv ${VENV}
+curl -O https://bootstrap.pypa.io/get-pip.py
+source ${VENV}/bin/activate
+python get-pip.py
+pip install -r "$(dirname $0)/requirements.txt"
+pip install git+https://github.com/ansible/ansible.git@devel
+# XXX: Have to symlink ansible -> ansible-playbook to get working
+pushd venv/bin/
+ln -sf ansible ansible-playbook
+popd
+# XXX: Only way to get the openstack.py plugin
+git clone https://github.com/ansible/ansible.git
 
-u=$(whoami)
-g=$(groups | awk '{print $1}')
 
-if [ ! -d /opt/stack ]; then
-    mkdir -p /opt/stack || (sudo mkdir -p /opt/stack)
-fi
-sudo -H chown -R $u:$g /opt/stack
-cd /opt/stack
-
-if [ ! -d ansible ]; then
-    git clone https://github.com/ansible/ansible.git --recursive
-else
-    cd ansible
-    git checkout devel
-    git pull --rebase
-    git submodule update --init --recursive
-    git fetch
-    # Temporary direct checkout of devel due to broken modules until
-    # the submodules pointers get updated in the core ansible repo.
-    cd lib/ansible/modules/core
-    git checkout devel
-fi
-
-echo
-echo "If your using this script directly, execute the"
-echo "following commands to update your shell."
-echo
-echo "source env-vars"
-echo "source /opt/stack/ansible/hacking/env-setup"
-echo
+echo ========================================================================
+echo If you have elected to provide cloud provider details via environment
+echo variables, source that file.  Otherwise, we assume you are managing that
+echo information with os-client-config and in that case, replace 'envvars' in
+echo your infra_config.yaml file with the name of a cloud provider you have
+echo ========================================================================


### PR DESCRIPTION
By installing everything into a virtualenv, we can drop assumptions
about the host, eliminate the need for privilege escalation to install
distro packages, and keeps the host system's global environment clean.
